### PR TITLE
fix: update usage for new sessionId API

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,44 +212,16 @@ In Android, it's easy to add a function to your native module to get the session
 fun getSessionId(): String? = otel()?.rumSessionId
 ```
 
-In iOS, it's a little more complicated. Start by adding a property to your Honeycomb wrapper to
-keep track of the ID.
+And in iOS, it's almost as easy. Add a method to your Swift wrapper.
 ```swift
-    private let sessionLock = NSLock()
-
-    private var _sessionId: String? = nil
-
-    @objc public var sessionId: String? {
-        get {
-            return sessionLock.withLock {
-                _sessionId
-            }
-        }
-        set(value) {
-            sessionLock.withLock {
-                _sessionId = value
-            }
-        }
+@objc public var sessionId: String? {
+    get {
+        return Honeycomb.currentSession()?.id
     }
+}
 ```
 
-Then, when configuring the SDK, add a listener to keep the member up to date.
-
-```swift
-    NotificationCenter.default.addObserver(
-        forName: .sessionStarted,
-        object: nil,
-        queue: .main
-    ) { notification in
-        guard let session = notification.userInfo?["session"] as? HoneycombSession else {
-          self.sessionId = nil
-          return
-        }
-        self.sessionId = session.id
-    }
-```
-
-Next, add a method to the Objective C native module code to call the wrapper.
+Then add a method to the Objective C native module code to call the wrapper.
 
 ```objectivec
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSessionId) {

--- a/ios/HoneycombWrapper.swift
+++ b/ios/HoneycombWrapper.swift
@@ -4,37 +4,14 @@ import Honeycomb
 import OpenTelemetryApi
 
 @objc public class HoneycombWrapper : NSObject {
-  private let sessionLock = NSLock()
-
-  private var _sessionId: String? = nil
-  
   @objc public var sessionId: String? {
     get {
-      return sessionLock.withLock {
-        _sessionId
-      }
-    }
-    set(value) {
-      sessionLock.withLock {
-        _sessionId = value
-      }
+      return Honeycomb.currentSession()?.id
     }
   }
   
 
   @objc public func configure() {
-    NotificationCenter.default.addObserver(
-        forName: .sessionStarted,
-        object: nil,
-        queue: .main
-    ) { notification in
-        guard let session = notification.userInfo?["session"] as? HoneycombSession else {
-          self.sessionId = nil
-          return
-        }
-        self.sessionId = session.id
-    }
-
     do {
         let options = try HoneycombOptions.Builder()
             .setAPIKey("YOUR-API-KEY-HERE")
@@ -44,16 +21,6 @@ import OpenTelemetryApi
     } catch {
         NSException(name: NSExceptionName("HoneycombOptionsError"), reason: "\(error)").raise()
     }
-    
-    // HACK: Send a span just to initialize the session ID.
-    let tracerProvider = OpenTelemetry.instance.tracerProvider.get(
-        instrumentationName: "swift sdk",
-        instrumentationVersion: nil
-    )
-    let span = tracerProvider
-      .spanBuilder(spanName: "init")
-      .startSpan()
-    span.end()
   }
 
   @objc public func sendSpan(parentId: String?, traceId: String?) {

--- a/ios/honeycombreactnativesample.xcodeproj/project.pbxproj
+++ b/ios/honeycombreactnativesample.xcodeproj/project.pbxproj
@@ -563,7 +563,7 @@
 			repositoryURL = "https://github.com/honeycombio/honeycomb-opentelemetry-swift/";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.7;
+				minimumVersion = 0.0.9;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/honeycombreactnativesample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/honeycombreactnativesample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/honeycombio/honeycomb-opentelemetry-swift/",
       "state" : {
-        "revision" : "20d39775b0ea710c8a0d6b9c43f32b893c473bfa",
-        "version" : "0.0.7"
+        "revision" : "22b2a1a75f956c2ae1e53d182cb12eb86049c2c2",
+        "version" : "0.0.9"
       }
     },
     {


### PR DESCRIPTION
## Which problem is this PR solving?

This updates the iOS code to use the new `currentSession` API on iOS, which is much simpler.

## Short description of the changes

The README has also been updated.

## How to verify that this has the expected result

I manually verified this still works.